### PR TITLE
fix: read override files to reflect Flatseal changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,13 @@
-# Copyright (C) 2026 lebachkhoa
-# Flatguard is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by the Free Software Foundation,
-# either version 3 of the License, or (at your option) any later version.
-
 cmake_minimum_required(VERSION 3.10)
-project(Flatguard VERSION 0.1.0 LANGUAGES CXX)
+project(Flatguard VERSION 0.1.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(SOURCES
     src/flatpak/parser.cpp
+    src/flatpak/override.cpp
+    src/utils/ini_utils.cpp
     src/audit/auditor.cpp
 )
 
@@ -22,6 +19,9 @@ target_include_directories(test_parser PRIVATE src third_party)
 
 add_executable(test_auditor tests/test_auditor.cpp ${SOURCES})
 target_include_directories(test_auditor PRIVATE src third_party)
+
+add_executable(test_override tests/test_override.cpp ${SOURCES})
+target_include_directories(test_override PRIVATE src third_party)
 
 enable_testing()
 
@@ -40,5 +40,8 @@ add_test(NAME TestParser COMMAND test_parser)
 
 target_link_libraries(test_auditor GTest::gtest_main)
 add_test(NAME TestAuditor COMMAND test_auditor)
+
+target_link_libraries(test_override GTest::gtest_main)
+add_test(NAME TestOverride COMMAND test_override)
 
 install(TARGETS flatguard DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A command-line security auditing tool for [Flatpak](https://flatpak.org/) applic
 - [Usage](#usage)
 - [Running Tests](#running-tests)
 - [Example Output](#example-output)
+- [Changelog](#changelog)
 - [License](#license)
 
 ---
@@ -34,8 +35,7 @@ Results are printed to the terminal with color-coded `CRITICAL` / `WARNING` / `I
 
 - Automatically discovers installed Flatpak apps under `$XDG_DATA_HOME/flatpak/app/` or `~/.local/share/flatpak/app/` and `/var/lib/flatpak/app/`
 - Parses INI-style Flatpak `metadata` files using [SimpleIni](https://github.com/brofield/simpleini)
-- **Context-aware auditing**: adjusts rule severity based on whether the permission makes sense for the app's declared purpose
-- Full CLI interface with `--audit`, `--list`, `--help`, `--version`
+- Full CLI interface with `--audit`, `--list`, `--json`, `--help`, `--version`
 - Color-coded output: **RED** for `CRITICAL`, **YELLOW** for `WARNING`, **CYAN** for `INFO`
 - Detects dangerous permission combinations (COMBO_01..COMBO_04) and reports them as `CRITICAL`.
 - Unit-tested with [Google Test](https://github.com/google/googletest)
@@ -73,13 +73,19 @@ flatguard/
 │   ├── color.h                # ANSI color codes for terminal output
 │   ├── flatpak/
 │   │   ├── parser.h           # AppPermissions struct, FlatpakParser declarations
-│   │   └── parser.cpp         # INI metadata parser, system scan
-│   └── audit/
-│       ├── auditor.h          # SecurityRule / AuditIssue structs, built-in rules
-│       └── auditor.cpp        # Context-aware rule-matching logic
+│   │   ├── parser.cpp         # INI metadata parser, system scan
+│   │   ├── override.h         # applyOverrides declaration
+│   │   └── override.cpp       # Applies system/user Flatpak overrides to permissions
+│   ├── audit/
+│   │   ├── auditor.h          # SecurityRule / AuditIssue structs, built-in rules
+│   │   └── auditor.cpp        # Context-aware rule-matching logic
+│   └── utils/
+│       ├── ini_utils.h        # parsePermissionsFromIni declaration
+│       └── ini_utils.cpp      # Shared INI parsing utilities
 ├── tests/
-│   ├── test_parser.cpp        # Unit tests for the metadata parser (4 tests)
-│   └── test_auditor.cpp       # Unit tests for the auditor (10 tests)
+│   ├── test_parser.cpp        # Unit tests for the metadata parser
+│   ├── test_override.cpp      # Unit tests for the override module
+│   └── test_auditor.cpp       # Unit tests for the auditor
 ├── third_party/
 │   ├── SimpleIni.h            # Header-only INI parser
 │   └── cxxopts.hpp            # Header-only CLI argument parser
@@ -117,13 +123,14 @@ cmake ..
 make
 ```
 
-This produces three binaries inside `build/`:
+This produces four binaries inside `build/`:
 
-| Binary         | Description                        |
-|----------------|------------------------------------|
-| `flatguard`    | The main CLI tool                  |
-| `test_parser`  | Unit tests for the parser module   |
-| `test_auditor` | Unit tests for the auditor module  |
+| Binary          | Description                         |
+|-----------------|-------------------------------------|
+| `flatguard`     | The main CLI tool                   |
+| `test_parser`   | Unit tests for the parser module    |
+| `test_override` | Unit tests for the override module  |
+| `test_auditor`  | Unit tests for the auditor module   |
 
 ---
 
@@ -161,11 +168,11 @@ cd build
 ./flatguard --audit all
 
 # Audit a single app by its ID
-./flatguard --audit com.google.Chrome
+./flatguard --audit org.mozilla.firefox
 
 # Output results as JSON (pipe-friendly)
 ./flatguard --json
-./flatguard --audit com.google.Chrome --json
+./flatguard --audit org.mozilla.firefox --json
 
 # List all installed Flatpak apps
 ./flatguard --list
@@ -197,6 +204,7 @@ cd build
 cd build
 
 ./test_parser
+./test_override
 ./test_auditor
 ```
 
@@ -211,9 +219,11 @@ Expected output:
 
 ```
     Start 1: TestParser
-1/2 Test #1: TestParser .......................   Passed    0.00 sec
+1/3 Test #1: TestParser .......................   Passed    0.00 sec
     Start 2: TestAuditor
-2/2 Test #2: TestAuditor ......................   Passed    0.00 sec
+2/3 Test #2: TestAuditor ......................   Passed    0.00 sec
+    Start 3: TestOverride
+3/3 Test #3: TestOverride .....................   Passed    0.00 sec
 ```
 
 ---
@@ -222,14 +232,13 @@ Expected output:
 ```
 $ ./flatguard --audit all
 
---------------------------------------------------
-Application: com.google.Chrome
+Application: org.mozilla.firefox
 --------------------------------------------------
 [+] Permissions Summary:
-    - Network:  Enabled
-    - Graphics: X11, Wayland
-    - Devices:  All Hardware (Webcam, Mic, etc.)
-    - Files:    host-etc, ~/.config/kioslaverc, xdg-music, xdg-pictures, xdg-videos, /run/.heim_org.h5l.kcm-socket, ~/.config/dconf:ro, xdg-download, xdg-run/dconf, xdg-documents, xdg-run/pipewire-0
+    - Shared:   network, ipc
+    - Sockets:  x11, wayland, pulseaudio, fallback-x11, pcsc, cups
+    - Devices:  all
+    - Files:    xdg-config/gtk-3.0:ro, xdg-download, /run/.heim_org.h5l.kcm-socket, xdg-run/speech-dispatcher:ro
 
 [!] Security Findings:
   [CRITICAL] DEV_01: App can access all hardware devices (webcam, etc.)
@@ -238,37 +247,31 @@ Application: com.google.Chrome
   [CRITICAL] COMBO_03: App can capture keystrokes and transmit them remotely.
   [CRITICAL] COMBO_04: App can stream webcam/microphone over the internet.
 --------------------------------------------------
---------------------------------------------------
-Application: org.videolan.VLC
+
+Application: com.github.tchx84.Flatseal
 --------------------------------------------------
 [+] Permissions Summary:
-    - Network:  Enabled
-    - Graphics: X11
-    - Devices:  All Hardware (Webcam, Mic, etc.)
-    - Files:    xdg-config/kdeglobals:ro, host, xdg-run/gvfs
+    - Shared:   ipc
+    - Sockets:  x11, wayland, fallback-x11
+    - Devices:  dri
+    - Files:    xdg-data/flatpak/overrides:create, /var/lib/flatpak/app:ro, xdg-data/flatpak/app:ro
 
 [!] Security Findings:
-  [CRITICAL] DEV_01: App can access all hardware devices (webcam, etc.)
-  [CRITICAL] FS_02: App has access to the entire host OS filesystem.
   [INFO]     SOC_01: X11 protocol is insecure and allows keylogging.
-  [INFO]     NET_01: App can communicate over the internet.
-  [CRITICAL] COMBO_02: App can exfiltrate the entire host filesystem over the internet.
-  [CRITICAL] COMBO_03: App can capture keystrokes and transmit them remotely.
-  [CRITICAL] COMBO_04: App can stream webcam/microphone over the internet.
 --------------------------------------------------
 ```
 
 **JSON output (`--json`):**
 ```json
-$ ./flatguard --audit com.google.Chrome --json
+$ ./flatguard --audit org.mozilla.firefox --json
 [
   {
-    "appId": "com.google.Chrome",
+    "appId": "org.mozilla.firefox",
     "permissions": {
-      "network": "Enabled",
-      "graphics": ["X11", "Wayland"],
-      "devices": "All Hardware",
-      "files": ["host-etc", "~/.config/kioslaverc", "xdg-music", "xdg-pictures", "xdg-videos", "/run/.heim_org.h5l.kcm-socket", "~/.config/dconf:ro", "xdg-download", "xdg-run/dconf", "xdg-documents", "xdg-run/pipewire-0"]
+      "shared": ["network", "ipc"],
+      "sockets": ["x11", "wayland", "pulseaudio", "fallback-x11", "pcsc", "cups"],
+      "devices": "all",
+      "files": ["xdg-config/gtk-3.0:ro", "xdg-download", "/run/.heim_org.h5l.kcm-socket", "xdg-run/speech-dispatcher:ro"]
     },
     "issues": [
       {
@@ -300,6 +303,33 @@ $ ./flatguard --audit com.google.Chrome --json
   }
 ]
 ```
+
+---
+
+## Changelog
+
+### v0.1.1 — 2026-03-08
+
+#### Fixed
+- **Override resolution**: `applyOverrides` now correctly resolves both system-level (`/var/lib/flatpak/overrides/`) and per-user (`$XDG_DATA_HOME/flatpak/overrides/` or `~/.local/share/flatpak/overrides/`) override files, and applies them in the correct order (system first, user second).
+- **Override token handling**: Denial tokens prefixed with `!` (e.g. `!network`) now properly remove the matching permission from the base permission list.
+- **Path handling consistency**: All file path operations now use `std::filesystem::path` throughout the codebase (`parseMetadata`, `scanSystem`, `applyOverrides`), eliminating fragile manual string concatenation.
+- **CLI argument validation**: Passing subcommand-style arguments without `--` (e.g. `flatguard audit <id>`) now emits a clear error with a suggested fix instead of silently auditing all apps.
+
+#### Internal
+- Extracted shared INI parsing logic into `src/utils/ini_utils.cpp`.
+- Added `test_override` unit test binary covering override resolution and token merging.
+
+---
+
+### v0.1.0 — Initial release
+
+- Scan all installed Flatpak apps from system and user paths.
+- Parse INI `metadata` files for permissions (shared, sockets, devices, filesystems).
+- Audit permissions against 6 security rules + 4 combo rules.
+- Color-coded terminal output (`CRITICAL` / `WARNING` / `INFO`).
+- CLI flags: `--audit`, `--list`, `--json`, `--help`, `--version`.
+- Unit tests for parser and auditor modules.
 
 ---
 

--- a/src/flatpak/override.cpp
+++ b/src/flatpak/override.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 lebachkhoa
+ * Flatguard is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include "parser.h"
+#include "override.h"
+#include "../utils/ini_utils.h"
+
+static void applyOverrideFile(AppPermissions& permissions, const std::filesystem::path& overridePath)
+{
+    if (!std::filesystem::exists(overridePath))
+        return;
+
+    CSimpleIniA ini;
+    SI_Error rc = ini.LoadFile(overridePath.string().c_str());
+    if (rc < 0) {
+        std::cerr << "Failed to load override file: " << overridePath << "\n";
+        return;
+    }
+
+    AppPermissions overridePerms;
+    FlatpakParser::parsePermissionsFromIni(ini, overridePerms);
+
+    auto applyList = [](std::vector<std::string>& base, const std::vector<std::string>& overrides) {
+        for (const auto& token : overrides) {
+            if (!token.empty() && token[0] == '!') {
+                const std::string denied = token.substr(1);
+                base.erase(std::remove(base.begin(), base.end(), denied), base.end());
+            } else {
+                if (std::find(base.begin(), base.end(), token) == base.end())
+                    base.push_back(token);
+            }
+        }
+    };
+
+    applyList(permissions.shared, overridePerms.shared);
+    applyList(permissions.sockets, overridePerms.sockets);
+    applyList(permissions.devices, overridePerms.devices);
+    applyList(permissions.filesystems, overridePerms.filesystems);
+}
+
+void FlatpakParser::applyOverrides(AppPermissions& permissions, const std::filesystem::path& appPath)
+{
+    std::filesystem::path installOverride =
+        appPath.parent_path().parent_path() / "overrides" / permissions.appId;
+
+    // Per-user override ($XDG_DATA_HOME or ~/.local/share)
+    std::filesystem::path userBase;
+    const char* xdgData = std::getenv("XDG_DATA_HOME");
+    if (xdgData != nullptr && std::string(xdgData) != "") {
+        userBase = std::filesystem::path(xdgData) / "flatpak" / "overrides";
+    }  
+    else if (const char* home = std::getenv("HOME")) {
+        userBase = std::filesystem::path(home) / ".local" / "share" / "flatpak" / "overrides";
+    }
+        
+    std::filesystem::path userOverride = userBase / permissions.appId;
+
+    applyOverrideFile(permissions, installOverride);
+    if (userOverride != installOverride) {
+        applyOverrideFile(permissions, userOverride);
+    }
+}

--- a/src/flatpak/override.h
+++ b/src/flatpak/override.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2026 lebachkhoa
+ * Flatguard is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+#include <filesystem>
+#include "parser.h"
+
+namespace FlatpakParser
+{
+    void applyOverrides(AppPermissions& permissions, const std::filesystem::path& appPath);
+};

--- a/src/flatpak/parser.cpp
+++ b/src/flatpak/parser.cpp
@@ -6,38 +6,14 @@
  */
 
 #include <iostream>
-#include <sstream>
 #include <cstdlib>
 #include <filesystem>
 #include "parser.h"
-#include "SimpleIni.h"
+#include "../../third_party/SimpleIni.h"
+#include "../utils/ini_utils.h"
+#include "override.h"
 
-// Flatpak metadata stores list values as semicolon-separated tokens.
-static std::string trim(const std::string& s)
-{
-    const std::string whitespace = " \t\n\r\f\v";
-    const auto start = s.find_first_not_of(whitespace);
-    if(start == std::string::npos) return "";
-
-    const auto end = s.find_last_not_of(whitespace);
-    const auto range = end - start + 1;
-    return s.substr(start, range);
-}
-
-static std::vector<std::string> splitBySemicolon(const std::string& str)
-{
-    std::vector<std::string> result;
-    std::istringstream stream(str);
-    std::string token;
-    while (std::getline(stream, token, ';')) {
-        std::string t = trim(token);
-        if (!t.empty())
-            result.push_back(t);
-    }
-    return result;
-}
-
-AppPermissions FlatpakParser::parseMetadata(const std::string& path)
+AppPermissions FlatpakParser::parseMetadata(const std::filesystem::path& path)
 {
     AppPermissions permissions;
 
@@ -51,65 +27,53 @@ AppPermissions FlatpakParser::parseMetadata(const std::string& path)
 
     permissions.appId = ini.GetValue(SECTION_APPLICATION, KEY_NAME, "unknown");
 
-    auto readList = [&](const char* section, const char* key,
-                        std::vector<std::string>& out) -> bool {
-        const char* value = ini.GetValue(section, key, nullptr);
-        if (!value)
-            return false;
-        out = splitBySemicolon(value);
-        return true;
-    };
-
-    readList(SECTION_CONTEXT, KEY_SHARED, permissions.shared);
-    readList(SECTION_CONTEXT, KEY_SOCKETS, permissions.sockets);
-    readList(SECTION_CONTEXT, KEY_DEVICES, permissions.devices);
-    readList(SECTION_CONTEXT, KEY_FILESYSTEMS, permissions.filesystems);
+    parsePermissionsFromIni(ini, permissions);
 
     return permissions;
 }
 
-std::vector<AppPermissions> FlatpakParser::scanSystem() 
+std::vector<AppPermissions> FlatpakParser::scanSystem()
 {
-   std::string userPath;
+    std::filesystem::path userPath;
 
-   const char* xdgData = std::getenv("XDG_DATA_HOME");
-   if(xdgData != nullptr && std::string(xdgData) != "") {
-      userPath = std::string(xdgData) + "/flatpak/app/";
-      std::cout << "Detected custom XDG path.\n";
-   } else {
-      const char* homeDir = std::getenv("HOME");   
-      if(homeDir != nullptr) {
-         userPath = std::string(homeDir) + "/.local/share/flatpak/app/";
-      } else {
-         std::cerr << "Error: Could not find HOME directory.\n";
-      }
-   }
-   
-   std::string systemPath = "/var/lib/flatpak/app/";
-   std::vector<AppPermissions> allApps;
+    const char* xdgData = std::getenv("XDG_DATA_HOME");
+    if (xdgData != nullptr && std::string(xdgData) != "") {
+        userPath = std::filesystem::path(xdgData) / "flatpak" / "app";
+    } else {
+        const char* homeDir = std::getenv("HOME");
+        if (homeDir != nullptr) {
+            userPath = std::filesystem::path(homeDir) / ".local" / "share" / "flatpak" / "app";
+        } else {
+            std::cerr << "Error: Could not find HOME directory.\n";
+        }
+    }
 
-   for (const auto& basePath : std::initializer_list<std::string>{ systemPath, userPath }) 
-   {
-      if (!std::filesystem::exists(basePath)) continue;
+    std::filesystem::path systemPath = "/var/lib/flatpak/app";
+    std::vector<AppPermissions> allApps;
 
-      try
-      {
-         for (const auto& appDir : std::filesystem::directory_iterator(basePath)) 
-         {
-            std::filesystem::path metadataPath = appDir.path() / "current/active/metadata";
+    for (const auto& basePath : std::initializer_list<std::filesystem::path>{ systemPath, userPath })
+    {
+        if (!std::filesystem::exists(basePath)) continue;
 
-            if (std::filesystem::exists(metadataPath)) 
+        try
+        {
+            for (const auto& appDir : std::filesystem::directory_iterator(basePath))
             {
-               AppPermissions appPerms = parseMetadata(metadataPath.string());
-               allApps.push_back(appPerms);
-            }
-         }
-      }
-      catch(const std::exception& e)
-      {
-         std::cerr << "Error parsing metadata: " << basePath << " - " << e.what() << '\n';
-      }
-   }
+                std::filesystem::path metadataPath = appDir.path() / "current/active/metadata";
 
-   return allApps;
+                if (std::filesystem::exists(metadataPath))
+                {
+                    AppPermissions appPerms = parseMetadata(metadataPath);
+                    applyOverrides(appPerms, appDir.path());
+                    allApps.push_back(appPerms);
+                }
+            }
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "Error parsing metadata: " << basePath << " - " << e.what() << '\n';
+        }
+    }
+
+    return allApps;
 }

--- a/src/flatpak/parser.h
+++ b/src/flatpak/parser.h
@@ -6,30 +6,31 @@
  */
 
 #pragma once
+#include <filesystem>
 #include <string>
 #include <vector>
 #include <set>
 
 struct AppPermissions
 {
-   std::string appId;
-   std::vector<std::string> shared;
-   std::vector<std::string> sockets;
-   std::vector<std::string> devices;
-   std::vector<std::string> filesystems;
+    std::string appId;
+    std::vector<std::string> shared;
+    std::vector<std::string> sockets;
+    std::vector<std::string> devices;
+    std::vector<std::string> filesystems;
 };
 
 namespace FlatpakParser
 {
-   inline constexpr const char* SECTION_APPLICATION   = "Application";
-   inline constexpr const char* KEY_NAME              = "name";
+    inline constexpr const char* SECTION_APPLICATION   = "Application";
+    inline constexpr const char* KEY_NAME              = "name";
 
-   inline constexpr const char* SECTION_CONTEXT       = "Context";
-   inline constexpr const char* KEY_SHARED            = "shared";
-   inline constexpr const char* KEY_SOCKETS           = "sockets";
-   inline constexpr const char* KEY_DEVICES           = "devices";
-   inline constexpr const char* KEY_FILESYSTEMS       = "filesystems";
+    inline constexpr const char* SECTION_CONTEXT       = "Context";
+    inline constexpr const char* KEY_SHARED            = "shared";
+    inline constexpr const char* KEY_SOCKETS           = "sockets";
+    inline constexpr const char* KEY_DEVICES           = "devices";
+    inline constexpr const char* KEY_FILESYSTEMS       = "filesystems";
 
-   AppPermissions parseMetadata(const std::string& path);
-   std::vector<AppPermissions> scanSystem();
+    AppPermissions parseMetadata(const std::filesystem::path& path);
+    std::vector<AppPermissions> scanSystem();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,17 +44,6 @@ static std::string joinOrNone(const std::vector<std::string>& v, const std::stri
     return out;
 }
 
-// Build a display-ready graphics list from raw sockets
-static std::vector<std::string> graphicsFromSockets(const std::vector<std::string>& sockets)
-{
-    std::vector<std::string> gfx;
-    for (const auto& s : sockets) {
-        if (s == "x11")     gfx.push_back("X11");
-        if (s == "wayland") gfx.push_back("Wayland");
-    }
-    return gfx;
-}
-
 // Escape special characters for JSON strings
 static std::string jsonEscape(const std::string& s)
 {
@@ -86,26 +75,30 @@ void printAuditIssuesJson(const std::vector<AppPermissions>& apps,
             if (issue.appId == app.appId)
                 appIssues.push_back(&issue);
 
-        bool hasNet    = std::find(app.shared.begin(),  app.shared.end(),  "network") != app.shared.end();
-        bool hasAllDev = std::find(app.devices.begin(), app.devices.end(), "all")     != app.devices.end();
-        auto gfx       = graphicsFromSockets(app.sockets);
+        bool hasAllDev = std::find(app.devices.begin(), app.devices.end(), "all") != app.devices.end();
 
         std::cout << "  {\n";
         std::cout << "    \"appId\": \""       << jsonEscape(app.appId) << "\",\n";
 
         // permissions object
         std::cout << "    \"permissions\": {\n";
-        std::cout << "      \"network\": \"" << (hasNet ? "Enabled" : "None") << "\",\n";
 
-        std::cout << "      \"graphics\": [";
-        for (size_t gi = 0; gi < gfx.size(); ++gi) {
-            if (gi) std::cout << ", ";
-            std::cout << "\"" << gfx[gi] << "\"";
+        std::cout << "      \"shared\": [";
+        for (size_t si = 0; si < app.shared.size(); ++si) {
+            if (si) std::cout << ", ";
+            std::cout << "\"" << jsonEscape(app.shared[si]) << "\"";
+        }
+        std::cout << "],\n";
+
+        std::cout << "      \"sockets\": [";
+        for (size_t si = 0; si < app.sockets.size(); ++si) {
+            if (si) std::cout << ", ";
+            std::cout << "\"" << jsonEscape(app.sockets[si]) << "\"";
         }
         std::cout << "],\n";
 
         if (hasAllDev) {
-            std::cout << "      \"devices\": \"All Hardware\",\n";
+            std::cout << "      \"devices\": \"all\",\n";
         } else {
             std::cout << "      \"devices\": [";
             for (size_t di = 0; di < app.devices.size(); ++di) {
@@ -159,23 +152,21 @@ void printAuditIssues(const std::vector<AppPermissions>& apps,
             if (issue.appId == app.appId)
                 appIssues.push_back(&issue);
 
-        bool hasNet    = std::find(app.shared.begin(),  app.shared.end(),  "network") != app.shared.end();
-        bool hasAllDev = std::find(app.devices.begin(), app.devices.end(), "all")     != app.devices.end();
-        auto gfx       = graphicsFromSockets(app.sockets);
-        std::string devStr  = hasAllDev ? "All Hardware (Webcam, Mic, etc.)" : joinOrNone(app.devices);
+        bool hasAllDev = std::find(app.devices.begin(), app.devices.end(), "all") != app.devices.end();
+        std::string devStr   = hasAllDev ? "all" : joinOrNone(app.devices);
         std::string filesStr = joinOrNone(app.filesystems);
 
         // ── Header ─────────────────────────────────────────────────────────
-        std::cout << SEP << "\n";
+        std::cout << "\n";
         std::cout << BOLD << "Application: " << app.appId << RESET << "\n";
         std::cout << SEP << "\n";
 
         // ── Permissions Summary ────────────────────────────────────────────
         std::cout << "[+] Permissions Summary:\n";
-        std::cout << "    - Network:  " << (hasNet ? "Enabled" : "None") << "\n";
-        std::cout << "    - Graphics: " << joinOrNone(gfx) << "\n";
-        std::cout << "    - Devices:  " << devStr << "\n";
-        std::cout << "    - Files:    " << filesStr << "\n";
+        std::cout << "    - Shared:   " << joinOrNone(app.shared)      << "\n";
+        std::cout << "    - Sockets:  " << joinOrNone(app.sockets)     << "\n";
+        std::cout << "    - Devices:  " << devStr                      << "\n";
+        std::cout << "    - Files:    " << filesStr                    << "\n";
 
         // ── Security Findings ─────────────────────────────────────────────
         std::cout << "\n[!] Security Findings:\n";
@@ -226,13 +217,23 @@ int main(int argc, char* argv[])
         return 1;
     }
 
+    const auto& unmatched = result.unmatched();
+    if (!unmatched.empty()) {
+        std::cerr << RED << "Error: unrecognized argument(s):";
+        for (const auto& u : unmatched) std::cerr << " '" << u << "'";
+        std::cerr << RESET << std::endl;
+        std::cerr << "Did you mean: " << BOLD << "--audit " << unmatched.back() << RESET << " ?" << std::endl;
+        std::cout << options.help() << std::endl;
+        return 1;
+    }
+
     if (result.count("help")) {
         std::cout << options.help() << std::endl;
         return 0;
     }
 
     if (result.count("version")) {
-        std::cout << "flatguard v0.1.0" << std::endl;
+        std::cout << "flatguard v0.1.1" << std::endl;
         return 0;
     }
 

--- a/src/utils/ini_utils.cpp
+++ b/src/utils/ini_utils.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 lebachkhoa
+ * Flatguard is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+
+#include "ini_utils.h"
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+    // Flatpak metadata stores list values as semicolon-separated tokens.
+    std::string trim(const std::string& s)
+    {
+        const std::string whitespace = " \t\n\r\f\v";
+        const auto start = s.find_first_not_of(whitespace);
+        if (start == std::string::npos) return "";
+
+        const auto end = s.find_last_not_of(whitespace);
+        const auto range = end - start + 1;
+        return s.substr(start, range);
+    }
+
+    // Split a string by semicolons and trim whitespace from each token.
+    std::vector<std::string> splitBySemicolon(const std::string& str)
+    {
+        std::vector<std::string> result;
+        std::istringstream stream(str);
+        std::string token;
+        while (std::getline(stream, token, ';')) {
+            std::string t = trim(token);
+            if (!t.empty())
+                result.push_back(t);
+        }
+        return result;
+    }
+}
+
+// Read permissions from the INI file and populate the AppPermissions struct.
+void FlatpakParser::parsePermissionsFromIni(CSimpleIniA& ini, AppPermissions& perm)
+{
+    auto readList = [&](const char* section, const char* key,
+                        std::vector<std::string>& out) -> bool {
+        const char* value = ini.GetValue(section, key, nullptr);
+        if (!value)
+            return false;
+        out = splitBySemicolon(value);
+        return true;
+    };
+
+    readList(SECTION_CONTEXT, KEY_SHARED, perm.shared);
+    readList(SECTION_CONTEXT, KEY_SOCKETS, perm.sockets);
+    readList(SECTION_CONTEXT, KEY_DEVICES, perm.devices);
+    readList(SECTION_CONTEXT, KEY_FILESYSTEMS, perm.filesystems);
+}

--- a/src/utils/ini_utils.h
+++ b/src/utils/ini_utils.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 lebachkhoa
+ * Flatguard is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+#include <string>
+#include <vector>
+#include "../../third_party/SimpleIni.h"
+#include "../flatpak/parser.h"
+
+namespace FlatpakParser {
+    void parsePermissionsFromIni(CSimpleIniA& ini, AppPermissions& perm);
+};

--- a/tests/test_override.cpp
+++ b/tests/test_override.cpp
@@ -1,0 +1,179 @@
+#include "gtest/gtest.h"
+#include "flatpak/parser.h"
+#include "flatpak/override.h"
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+static const std::filesystem::path kTestBase =
+    std::filesystem::temp_directory_path() / "fg_override_test";
+
+// Write override file and return the appPath to pass to applyOverrides().
+static std::filesystem::path setupOverrideFile(const std::string& appId, const std::string& content)
+{
+    std::filesystem::path overrideDir = kTestBase / "flatpak" / "overrides";
+    std::filesystem::create_directories(overrideDir);
+
+    std::ofstream f(overrideDir / appId);
+    f << content;
+    f.close();
+
+    setenv("XDG_DATA_HOME", kTestBase.string().c_str(), /*overwrite=*/1);
+
+    std::filesystem::path appPath = kTestBase / "flatpak" / "app" / appId;
+    std::filesystem::create_directories(appPath);
+    return appPath;
+}
+
+static void cleanupOverrideTest()
+{
+    unsetenv("XDG_DATA_HOME");
+    std::filesystem::remove_all(kTestBase);
+}
+
+// ---------------------------------------------------------
+
+// No override file → permissions stay unchanged
+TEST(OverrideTests, NoOverrideFile)
+{
+    cleanupOverrideTest(); // ensure no stray files
+    setenv("XDG_DATA_HOME", kTestBase.string().c_str(), 1);
+
+    AppPermissions perms;
+    perms.appId = "com.example.nooverride";
+    perms.shared = {"network", "ipc"};
+
+    std::filesystem::path appPath = kTestBase / "flatpak" / "app" / perms.appId;
+    std::filesystem::create_directories(appPath);
+
+    FlatpakParser::applyOverrides(perms, appPath);
+
+    ASSERT_EQ(perms.shared.size(), 2u);
+    EXPECT_EQ(perms.shared[0], "network");
+    EXPECT_EQ(perms.shared[1], "ipc");
+
+    cleanupOverrideTest();
+}
+
+// Override with !token → removes that token from base
+TEST(OverrideTests, RemoveSinglePermission)
+{
+    AppPermissions perms;
+    perms.appId = "org.mozilla.firefox";
+    perms.shared = {"network", "ipc"};
+
+    auto appPath = setupOverrideFile("org.mozilla.firefox", "[Context]\nshared=!network\n");
+
+    FlatpakParser::applyOverrides(perms, appPath);
+
+    ASSERT_EQ(perms.shared.size(), 1u);
+    EXPECT_EQ(perms.shared[0], "ipc");
+
+    cleanupOverrideTest();
+}
+
+// Override removes multiple tokens in one field
+TEST(OverrideTests, RemoveMultiplePermissions)
+{
+    AppPermissions perms;
+    perms.appId   = "com.example.app";
+    perms.shared  = {"network", "ipc"};
+    perms.sockets = {"x11", "wayland", "pulseaudio"};
+
+    auto appPath = setupOverrideFile("com.example.app",
+        "[Context]\nshared=!network;!ipc\nsockets=!x11;!pulseaudio\n");
+
+    FlatpakParser::applyOverrides(perms, appPath);
+
+    EXPECT_TRUE(perms.shared.empty());
+    ASSERT_EQ(perms.sockets.size(), 1u);
+    EXPECT_EQ(perms.sockets[0], "wayland");
+
+    cleanupOverrideTest();
+}
+
+// Override adds a new permission not in base
+TEST(OverrideTests, AddNewPermission)
+{
+    AppPermissions perms;
+    perms.appId   = "com.example.app";
+    perms.devices = {"dri"};
+
+    auto appPath = setupOverrideFile("com.example.app", "[Context]\ndevices=kvm\n");
+
+    FlatpakParser::applyOverrides(perms, appPath);
+
+    ASSERT_EQ(perms.devices.size(), 2u);
+    EXPECT_EQ(perms.devices[0], "dri");
+    EXPECT_EQ(perms.devices[1], "kvm");
+
+    cleanupOverrideTest();
+}
+
+// Override tries to remove a token that doesn't exist → no crash, list unchanged
+TEST(OverrideTests, RemoveNonExistentPermission)
+{
+    AppPermissions perms;
+    perms.appId  = "com.example.app";
+    perms.shared = {"ipc"};
+
+    auto appPath = setupOverrideFile("com.example.app", "[Context]\nshared=!network\n");
+
+    EXPECT_NO_THROW(FlatpakParser::applyOverrides(perms, appPath));
+
+    ASSERT_EQ(perms.shared.size(), 1u);
+    EXPECT_EQ(perms.shared[0], "ipc");
+
+    cleanupOverrideTest();
+}
+
+// Override does not duplicate an already-present permission
+TEST(OverrideTests, NoDuplicateWhenAddingExisting)
+{
+    AppPermissions perms;
+    perms.appId  = "com.example.app";
+    perms.shared = {"network"};
+
+    auto appPath = setupOverrideFile("com.example.app", "[Context]\nshared=network\n");
+
+    FlatpakParser::applyOverrides(perms, appPath);
+
+    ASSERT_EQ(perms.shared.size(), 1u);
+
+    cleanupOverrideTest();
+}
+
+// Override applies across all four fields at once
+TEST(OverrideTests, AllFieldsApplied)
+{
+    AppPermissions perms;
+    perms.appId       = "com.example.app";
+    perms.shared      = {"network", "ipc"};
+    perms.sockets     = {"x11", "wayland"};
+    perms.devices     = {"dri"};
+    perms.filesystems = {"xdg-download", "xdg-music"};
+
+    auto appPath = setupOverrideFile("com.example.app",
+        "[Context]\n"
+        "shared=!ipc\n"
+        "sockets=!wayland\n"
+        "devices=kvm\n"
+        "filesystems=!xdg-music\n");
+
+    FlatpakParser::applyOverrides(perms, appPath);
+
+    ASSERT_EQ(perms.shared.size(),      1u); EXPECT_EQ(perms.shared[0],      "network");
+    ASSERT_EQ(perms.sockets.size(),     1u); EXPECT_EQ(perms.sockets[0],     "x11");
+    ASSERT_EQ(perms.devices.size(),     2u); EXPECT_EQ(perms.devices[1],     "kvm");
+    ASSERT_EQ(perms.filesystems.size(), 1u); EXPECT_EQ(perms.filesystems[0], "xdg-download");
+
+    cleanupOverrideTest();
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -36,7 +36,7 @@ TEST(ParserTests, ParseMetadataShared) {
     std::remove(testFile.c_str());
 }
 
-// Test parseMetadata returns "unknow" when keys are missing
+// Test parseMetadata returns "unknown" when keys are missing
 TEST(ParserTests, ParseMetadataMissingKeys) {
     std::string testFile = "/tmp/test_metadata_empty.ini";
 


### PR DESCRIPTION
flatguard now reads override files from:

~/.local/share/flatpak/overrides/

/var/lib/flatpak/overrides/

Changes made via Flatseal or flatpak override command are now reflected correctly.