### PR TITLE
parse file system permissions with access level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(Flatguard VERSION 0.1.1 LANGUAGES CXX)
+project(Flatguard VERSION 0.2.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(SOURCES
     src/flatpak/parser.cpp
     src/flatpak/override.cpp
+    src/flatpak/fs_permissions.cpp
     src/utils/ini_utils.cpp
     src/audit/auditor.cpp
 )
@@ -22,6 +23,9 @@ target_include_directories(test_auditor PRIVATE src third_party)
 
 add_executable(test_override tests/test_override.cpp ${SOURCES})
 target_include_directories(test_override PRIVATE src third_party)
+
+add_executable(test_fs_permissions tests/test_fs_permissions.cpp ${SOURCES})
+target_include_directories(test_fs_permissions PRIVATE src third_party)
 
 enable_testing()
 
@@ -43,5 +47,8 @@ add_test(NAME TestAuditor COMMAND test_auditor)
 
 target_link_libraries(test_override GTest::gtest_main)
 add_test(NAME TestOverride COMMAND test_override)
+
+target_link_libraries(test_fs_permissions GTest::gtest_main)
+add_test(NAME TestFsPermissions COMMAND test_fs_permissions)
 
 install(TARGETS flatguard DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -44,23 +44,42 @@ Results are printed to the terminal with color-coded `CRITICAL` / `WARNING` / `I
 
 ## Security Rules
 
-| Rule ID | Default Severity | Permission Checked    | Description                                                   |
-|---------|------------------|-----------------------|---------------------------------------------------------------|
-| DEV_01  | CRITICAL         | `devices=all`         | App can access all hardware devices (webcam, microphone, etc.)|
-| FS_01   | INFO             | `filesystems=home`    | App can read and write your personal home directory           |
-| FS_02   | CRITICAL         | `filesystems=host`    | App has access to the entire host OS filesystem               |
-| SOC_01  | INFO             | `sockets=x11`         | X11 protocol is insecure and allows keylogging                |
-| NET_01  | INFO             | `shared=network`      | App can communicate over the internet                         |
-| DBUS_01 | WARNING          | `sockets=session-bus` | App can talk to other apps — potential sandbox escape         |
+| Rule ID    | Default Severity | Permission Checked      | Description                                                         |
+|------------|------------------|-------------------------|---------------------------------------------------------------------|
+| DEV_01     | CRITICAL         | `devices=all`           | App can access all hardware devices (webcam, microphone, etc.)      |
+| FS_01      | WARNING          | `filesystems=home`      | App has read/write access to your entire home directory             |
+| FS_02      | CRITICAL         | `filesystems=host`      | App has full read/write access to the entire host OS filesystem     |
+| SOC_01     | INFO             | `sockets=x11`           | X11 protocol is insecure and allows keylogging                      |
+| NET_01     | INFO             | `shared=network`        | App can communicate over the internet                               |
+| DBUS_01    | WARNING          | `sockets=session-bus`   | App can talk to other apps — potential sandbox escape               |
+| PERSIST_01 | CRITICAL         | `persistent=.`          | App persists the entire home directory outside the sandbox          |
+| PERSIST_02 | WARNING          | `persistent=.config`    | App persists all configuration files outside the sandbox            |
+| PERSIST_03 | CRITICAL         | `persistent=.ssh`       | App persists SSH keys outside the sandbox                           |
+| PERSIST_04 | CRITICAL         | `persistent=.gnupg`     | App persists GPG keys outside the sandbox                           |
+
+### Filesystem access-mode severity
+
+Flatpak filesystem entries can carry an optional access modifier (`:ro`, `:create`). Flatguard adjusts severity accordingly:
+
+| Entry | Rule severity |
+|---|---|
+| `home` / `home:create` | WARNING |
+| `home:ro` | INFO (downgraded one level) |
+| `host` / `host:create` | CRITICAL |
+| `host:ro` | WARNING (downgraded one level) |
 
 ### Combo (risk) rules
 
-Flatguard also detects dangerous permission *combinations* that greatly increase risk. These "combo" rules are reported as `CRITICAL`:
+Flatguard also detects dangerous permission *combinations*. Severity depends on whether filesystem access is writable:
 
-- `COMBO_01`: `network + home` — App can exfiltrate personal files over the internet.
-- `COMBO_02`: `network + host` — App can exfiltrate the entire host filesystem.
-- `COMBO_03`: `network + x11` — App can capture keystrokes (keylogging) and transmit them remotely.
-- `COMBO_04`: `network + devices=all` — App can stream webcam/microphone over the internet.
+| Rule     | Permissions               | Writable | Severity   |
+|----------|---------------------------|----------|------------|
+| COMBO_01 | `network + home`          | yes      | CRITICAL   |
+| COMBO_01 | `network + home:ro`       | no       | WARNING    |
+| COMBO_02 | `network + host`          | yes      | CRITICAL   |
+| COMBO_02 | `network + host:ro`       | no       | WARNING    |
+| COMBO_03 | `network + x11`           | —        | CRITICAL   |
+| COMBO_04 | `network + devices=all`   | —        | CRITICAL   |
 
 ---
 
@@ -75,7 +94,9 @@ flatguard/
 │   │   ├── parser.h           # AppPermissions struct, FlatpakParser declarations
 │   │   ├── parser.cpp         # INI metadata parser, system scan
 │   │   ├── override.h         # applyOverrides declaration
-│   │   └── override.cpp       # Applies system/user Flatpak overrides to permissions
+│   │   ├── override.cpp       # Applies system/user Flatpak overrides to permissions
+│   │   ├── fs_permissions.h   # FsPermission struct, FsAccess enum
+│   │   └── fs_permissions.cpp # Structured filesystem permission parser
 │   ├── audit/
 │   │   ├── auditor.h          # SecurityRule / AuditIssue structs, built-in rules
 │   │   └── auditor.cpp        # Context-aware rule-matching logic
@@ -85,7 +106,8 @@ flatguard/
 ├── tests/
 │   ├── test_parser.cpp        # Unit tests for the metadata parser
 │   ├── test_override.cpp      # Unit tests for the override module
-│   └── test_auditor.cpp       # Unit tests for the auditor
+│   ├── test_auditor.cpp       # Unit tests for the auditor
+│   └── test_fs_permissions.cpp# Unit tests for the filesystem permission parser
 ├── third_party/
 │   ├── SimpleIni.h            # Header-only INI parser
 │   └── cxxopts.hpp            # Header-only CLI argument parser
@@ -123,14 +145,15 @@ cmake ..
 make
 ```
 
-This produces four binaries inside `build/`:
+This produces five binaries inside `build/`:
 
-| Binary          | Description                         |
-|-----------------|-------------------------------------|
-| `flatguard`     | The main CLI tool                   |
-| `test_parser`   | Unit tests for the parser module    |
-| `test_override` | Unit tests for the override module  |
-| `test_auditor`  | Unit tests for the auditor module   |
+| Binary                 | Description                                      |
+|------------------------|--------------------------------------------------|
+| `flatguard`            | The main CLI tool                                |
+| `test_parser`          | Unit tests for the parser module                 |
+| `test_override`        | Unit tests for the override module               |
+| `test_auditor`         | Unit tests for the auditor module                |
+| `test_fs_permissions`  | Unit tests for the filesystem permission parser  |
 
 ---
 
@@ -206,6 +229,7 @@ cd build
 ./test_parser
 ./test_override
 ./test_auditor
+./test_fs_permissions
 ```
 
 Or using CTest:
@@ -219,11 +243,17 @@ Expected output:
 
 ```
     Start 1: TestParser
-1/3 Test #1: TestParser .......................   Passed    0.00 sec
+1/4 Test #1: TestParser .......................   Passed    0.00 sec
     Start 2: TestAuditor
-2/3 Test #2: TestAuditor ......................   Passed    0.00 sec
+2/4 Test #2: TestAuditor ......................   Passed    0.00 sec
     Start 3: TestOverride
-3/3 Test #3: TestOverride .....................   Passed    0.00 sec
+3/4 Test #3: TestOverride .....................   Passed    0.01 sec
+    Start 4: TestFsPermissions
+4/4 Test #4: TestFsPermissions ................   Passed    0.00 sec
+
+100% tests passed, 0 tests failed out of 4
+
+Total Test time (real) =   0.02 sec
 ```
 
 ---
@@ -235,15 +265,18 @@ $ ./flatguard --audit all
 Application: org.mozilla.firefox
 --------------------------------------------------
 [+] Permissions Summary:
-    - Shared:   network, ipc
-    - Sockets:  x11, wayland, pulseaudio, fallback-x11, pcsc, cups
-    - Devices:  all
-    - Files:    xdg-config/gtk-3.0:ro, xdg-download, /run/.heim_org.h5l.kcm-socket, xdg-run/speech-dispatcher:ro
+    - Shared:      network, ipc
+    - Sockets:     x11, wayland, pulseaudio, fallback-x11, pcsc, cups
+    - Devices:     all
+    - Files:       xdg-config/gtk-3.0:ro, xdg-download, /run/.heim_org.h5l.kcm-socket, xdg-run/speech-dispatcher:ro, home:ro
+    - Persistent:  .mozilla
 
 [!] Security Findings:
-  [CRITICAL] DEV_01: App can access all hardware devices (webcam, etc.)
+  [CRITICAL] DEV_01: App has full access to all hardware devices (webcam, etc.)
+  [INFO]     FS_01: App has read-only access to your entire home directory.
   [INFO]     SOC_01: X11 protocol is insecure and allows keylogging.
-  [INFO]     NET_01: App can communicate over the internet.
+  [INFO]     NET_01: App has full network access.
+  [WARNING]  COMBO_01: App can exfiltrate personal files over the internet.
   [CRITICAL] COMBO_03: App can capture keystrokes and transmit them remotely.
   [CRITICAL] COMBO_04: App can stream webcam/microphone over the internet.
 --------------------------------------------------
@@ -251,10 +284,11 @@ Application: org.mozilla.firefox
 Application: com.github.tchx84.Flatseal
 --------------------------------------------------
 [+] Permissions Summary:
-    - Shared:   ipc
-    - Sockets:  x11, wayland, fallback-x11
-    - Devices:  dri
-    - Files:    xdg-data/flatpak/overrides:create, /var/lib/flatpak/app:ro, xdg-data/flatpak/app:ro
+    - Shared:      ipc
+    - Sockets:     x11, wayland, fallback-x11
+    - Devices:     dri
+    - Files:       xdg-data/flatpak/overrides:create, /var/lib/flatpak/app:ro, xdg-data/flatpak/app:ro
+    - Persistent:  None
 
 [!] Security Findings:
   [INFO]     SOC_01: X11 protocol is insecure and allows keylogging.
@@ -263,7 +297,7 @@ Application: com.github.tchx84.Flatseal
 
 **JSON output (`--json`):**
 ```json
-$ ./flatguard --audit org.mozilla.firefox --json
+$ ./flatguard --audit all --json
 [
   {
     "appId": "org.mozilla.firefox",
@@ -271,13 +305,19 @@ $ ./flatguard --audit org.mozilla.firefox --json
       "shared": ["network", "ipc"],
       "sockets": ["x11", "wayland", "pulseaudio", "fallback-x11", "pcsc", "cups"],
       "devices": "all",
-      "files": ["xdg-config/gtk-3.0:ro", "xdg-download", "/run/.heim_org.h5l.kcm-socket", "xdg-run/speech-dispatcher:ro"]
+      "files": ["xdg-config/gtk-3.0:ro", "xdg-download", "/run/.heim_org.h5l.kcm-socket", "xdg-run/speech-dispatcher:ro", "home:ro"],
+      "persistent": [".mozilla"]
     },
     "issues": [
       {
         "ruleId": "DEV_01",
         "severity": "CRITICAL",
-        "description": "App can access all hardware devices (webcam, etc.)"
+        "description": "App has full access to all hardware devices (webcam, etc.)"
+      },
+      {
+        "ruleId": "FS_01",
+        "severity": "INFO",
+        "description": "App has read-only access to your entire home directory."
       },
       {
         "ruleId": "SOC_01",
@@ -287,7 +327,12 @@ $ ./flatguard --audit org.mozilla.firefox --json
       {
         "ruleId": "NET_01",
         "severity": "INFO",
-        "description": "App can communicate over the internet."
+        "description": "App has full network access."
+      },
+      {
+        "ruleId": "COMBO_01",
+        "severity": "WARNING",
+        "description": "App can exfiltrate personal files over the internet."
       },
       {
         "ruleId": "COMBO_03",
@@ -300,6 +345,23 @@ $ ./flatguard --audit org.mozilla.firefox --json
         "description": "App can stream webcam/microphone over the internet."
       }
     ]
+  },
+  {
+    "appId": "com.github.tchx84.Flatseal",
+    "permissions": {
+      "shared": ["ipc"],
+      "sockets": ["x11", "wayland", "fallback-x11"],
+      "devices": ["dri"],
+      "files": ["xdg-data/flatpak/overrides:create", "/var/lib/flatpak/app:ro", "xdg-data/flatpak/app:ro"],
+      "persistent": []
+    },
+    "issues": [
+      {
+        "ruleId": "SOC_01",
+        "severity": "INFO",
+        "description": "X11 protocol is insecure and allows keylogging."
+      }
+    ]
   }
 ]
 ```
@@ -307,6 +369,27 @@ $ ./flatguard --audit org.mozilla.firefox --json
 ---
 
 ## Changelog
+
+### v0.2.0 — 2026-03-10
+
+#### Added
+- **`persistent` permission support** — Flatpak `[Context] persistent=` entries are now parsed (`ini_utils.cpp`), stored in `AppPermissions`, displayed in output, and audited against 4 new rules: `PERSIST_01` (`.` — CRITICAL), `PERSIST_02` (`.config` — WARNING), `PERSIST_03` (`.ssh` — CRITICAL), `PERSIST_04` (`.gnupg` — CRITICAL).
+- **Structured filesystem permission parser** (`fs_permissions.h/cpp`) — Flatpak filesystem entries (e.g. `home:ro`, `host:create`) are now parsed into structured `FsPermission { path, FsAccess }` objects with `ReadWrite`, `ReadOnly`, and `Create` variants.
+- **Access-mode severity adjustment** — filesystem rules now account for the `:ro`/`:create` suffix: severity is downgraded one level when access is read-only (`CRITICAL→WARNING`, `WARNING→INFO`).
+- **`test_fs_permissions`** — new test binary with 13 unit tests covering all access modes, path varieties, deny prefix handling, and edge cases.
+- **`persistent` field in output** — both text and JSON output now include the `persistent` field.
+- **Deny-prefix guard in parser** — `parseFilesystemPermissions` now silently skips entries prefixed with `!` (deny tokens from override files).
+
+#### Changed
+- `FS_01` (`filesystems=home`) severity raised from `INFO` → `WARNING` — read/write home access is a meaningful risk.
+- Combo rules `COMBO_01`/`COMBO_02` severity is now `CRITICAL` when the filesystem access is writable, and `WARNING` when read-only.
+- `test_auditor` expanded from 10 → 21 test cases to cover new scenarios.
+
+#### Fixed
+- `auditor.cpp` matched raw strings against `app.filesystems`, so `"home:ro"` would never match rule pattern `"home"`. Now uses `parseFilesystemPermissions` for all filesystem rule matching.
+- Removed unused `#include <iostream>` from `auditor.cpp`.
+
+---
 
 ### v0.1.1 — 2026-03-08
 

--- a/src/audit/auditor.cpp
+++ b/src/audit/auditor.cpp
@@ -6,16 +6,45 @@
  */
 
 #include "auditor.h"
-#include <iostream>
+#include "flatpak/fs_permissions.h"
 #include <algorithm>
 
 std::vector<AuditIssue> Auditor::auditApp(const AppPermissions& app)
 {
     std::vector<AuditIssue> issues;
 
-    // Helper: check if a permission list contains a given value
+    // Helper: check if a plain permission list contains a given value
     auto contains = [](const std::vector<std::string>& v, const std::string& val) {
         return std::find(v.begin(), v.end(), val) != v.end();
+    };
+
+    // Parse filesystem entries into structured FsPermission objects so that
+    // entries like "home:ro" are correctly matched by path regardless of suffix.
+    const std::vector<FsPermission> fsParsed =
+        FlatpakParser::parseFilesystemPermissions(app.filesystems);
+
+    // Helper: check if any parsed filesystem entry has a given path (no suffix, read-write).
+    auto containsFsPath = [&](const std::string& path) {
+        return std::any_of(fsParsed.begin(), fsParsed.end(),
+            [&](const FsPermission& p) {
+                return p.path == path && p.fsaccess == FsAccess::ReadWrite;
+            });
+    };
+
+    // Helper: check if any parsed filesystem entry has a given path with :create access.
+    auto containsFsPathCreatable = [&](const std::string& path) {
+        return std::any_of(fsParsed.begin(), fsParsed.end(),
+            [&](const FsPermission& p) {
+                return p.path == path && p.fsaccess == FsAccess::Create;
+            });
+    };
+
+    // Helper: check if any parsed filesystem entry has a given path with :ro access.
+    auto containsFsPathReadOnly = [&](const std::string& path) {
+        return std::any_of(fsParsed.begin(), fsParsed.end(),
+            [&](const FsPermission& p) {
+                return p.path == path && p.fsaccess == FsAccess::ReadOnly;
+            });
     };
 
     // ── Single-permission rules ──────────────────────────────────────────────
@@ -24,32 +53,61 @@ std::vector<AuditIssue> Auditor::auditApp(const AppPermissions& app)
         const auto& field   = rule.target_field;
         const auto& pattern = rule.pattern;
 
-        const std::vector<std::string>* list = nullptr;
-        if      (field == "devices")     list = &app.devices;
-        else if (field == "filesystems") list = &app.filesystems;
-        else if (field == "sockets")     list = &app.sockets;
-        else if (field == "shared")      list = &app.shared;
+        bool matched = false;
+        if (field == "devices") {
+            matched = contains(app.devices, pattern);
+        } else if (field == "sockets") {
+            matched = contains(app.sockets, pattern);
+        } else if (field == "shared") {
+            matched = contains(app.shared, pattern);
+        } else if (field == "filesystems") {
+            matched = containsFsPath(pattern) || containsFsPathCreatable(pattern) || containsFsPathReadOnly(pattern);
+        } else if (field == "persistent") {
+            matched = contains(app.persistent, pattern);
+        }
 
-        if (!list) continue;
-        if (!contains(*list, pattern)) continue;
+        if (!matched) continue;
 
-        issues.push_back({app.appId, rule.id, rule.severity, rule.description});
+        // Adjust severity and description when filesystem access is read-only:
+        // downgrade one level (CRITICAL→WARNING, WARNING→INFO).
+        // Only applies when there is no rw/create entry for the same path.
+        Severity sev = rule.severity;
+        std::string desc = rule.description;
+        if (field == "filesystems" && rule.severity > Severity::INFO
+                && containsFsPathReadOnly(pattern)
+                && !containsFsPath(pattern) && !containsFsPathCreatable(pattern)) {
+            sev = (rule.severity == Severity::CRITICAL) ? Severity::WARNING : Severity::INFO;
+            // Replace "read/write" wording with "read-only" in the description.
+            const std::string rw = "read/write";
+            auto pos = desc.find(rw);
+            if (pos != std::string::npos)
+                desc.replace(pos, rw.size(), "read-only");
+        }
+
+        issues.push_back({app.appId, rule.id, sev, desc});
     }
 
     // ── Combo rules: dangerous permission combinations ───────────────────────
-    bool hasNetwork = contains(app.shared,      "network");
-    bool hasHome    = contains(app.filesystems, "home");
-    bool hasHost    = contains(app.filesystems, "host");
-    bool hasX11     = contains(app.sockets,     "x11");
-    bool hasDevices = contains(app.devices,     "all");
+    bool hasNetwork  = contains(app.shared,  "network");
+    bool hasHome     = containsFsPath("home") || containsFsPathCreatable("home") || containsFsPathReadOnly("home");
+    bool hasHost     = containsFsPath("host") || containsFsPathCreatable("host") || containsFsPathReadOnly("host");
+    bool hasX11      = contains(app.sockets, "x11");
+    bool hasDevices  = contains(app.devices, "all");
 
-    if (hasNetwork && hasHome)
-        issues.push_back({app.appId, "COMBO_01", Severity::CRITICAL,
+    // Combo is CRITICAL only when home/host has write access (ro is still bad but less so).
+    if (hasNetwork && hasHome) {
+        bool writable = containsFsPath("home") || containsFsPathCreatable("home");
+        Severity sev = writable ? Severity::CRITICAL : Severity::WARNING;
+        issues.push_back({app.appId, "COMBO_01", sev,
             "App can exfiltrate personal files over the internet."});
+    }
 
-    if (hasNetwork && hasHost)
-        issues.push_back({app.appId, "COMBO_02", Severity::CRITICAL,
+    if (hasNetwork && hasHost) {
+        bool writable = containsFsPath("host") || containsFsPathCreatable("host");
+        Severity sev = writable ? Severity::CRITICAL : Severity::WARNING;
+        issues.push_back({app.appId, "COMBO_02", sev,
             "App can exfiltrate the entire host filesystem over the internet."});
+    }
 
     if (hasNetwork && hasX11)
         issues.push_back({app.appId, "COMBO_03", Severity::CRITICAL,

--- a/src/audit/auditor.h
+++ b/src/audit/auditor.h
@@ -40,15 +40,15 @@ namespace Auditor
     inline const std::vector<SecurityRule> securityRules = {
         {
             "DEV_01", "Full Device Access", "devices", "all", 
-            Severity::CRITICAL, "App can access all hardware devices (webcam, etc.)"
+            Severity::CRITICAL, "App has full access to all hardware devices (webcam, etc.)"
         },
         {
             "FS_01", "Home Access", "filesystems", "home", 
-            Severity::INFO, "App can read/write your entire personal home directory."
+            Severity::WARNING, "App has read/write access to your entire home directory."
         },
         {
             "FS_02", "Host Filesystem Access", "filesystems", "host", 
-            Severity::CRITICAL, "App has access to the entire host OS filesystem."
+            Severity::CRITICAL, "App has full read/write access to the entire host OS filesystem."
         },
         {
             "SOC_01", "X11 Risk", "sockets", "x11", 
@@ -56,12 +56,28 @@ namespace Auditor
         },
         {
             "NET_01", "Network Access", "shared", "network", 
-            Severity::INFO, "App can communicate over the internet."
+            Severity::INFO, "App has full network access."
         },
         {
             "DBUS_01", "D-Bus Session Access", "sockets", "session-bus", 
-            Severity::WARNING, "App can talk to other apps, potential sandbox escape."
-        }
+            Severity::WARNING, "App has full access to D-Bus session, potential sandbox escape."
+        },
+        {
+            "PERSIST_01", "Full Home Persistence", "persistent", ".",
+            Severity::CRITICAL, "App has full persistence of entire home directory outside sandbox."
+        },
+        {
+            "PERSIST_02", "Config Directory Persistence", "persistent", ".config",
+            Severity::WARNING, "App has full persistence of all configuration files outside sandbox."
+        },
+        {
+            "PERSIST_03", "SSH Keys Persistence",  "persistent", ".ssh", 
+            Severity::CRITICAL, "App has full persistence of SSH keys."
+        },
+        {
+            "PERSIST_04", "GPG Keys Persistence",  "persistent", ".gnupg", 
+            Severity::CRITICAL, "App has full persistence of GPG keys."
+        },
     };
 
     std::vector<AuditIssue> auditApp(const AppPermissions& app);

--- a/src/flatpak/fs_permissions.cpp
+++ b/src/flatpak/fs_permissions.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 lebachkhoa
+ * Flatguard is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+
+#include "fs_permissions.h"
+#include <filesystem>
+
+// Flatpak filesystem entries have the form:
+// <path>[:<access>]
+// <path>   : logical name (home, host, xdg-*, /absolute, ~/relative, ...)
+// <access> : ro | create
+
+std::vector<FsPermission> FlatpakParser::parseFilesystemPermissions(const std::vector<std::string>& fsEntries)
+{
+    std::vector<FsPermission> permissions;
+
+    for (const auto& entry : fsEntries) {
+        if (entry.empty()) continue;
+
+        // Skip deny entries (prefixed with '!')
+        if (entry.front() == '!') continue;
+
+        // Split on the first ':' to separate path from access modifier
+        const auto colonPos = entry.find(':');
+        std::string path   = (colonPos != std::string::npos) ? entry.substr(0, colonPos) : entry;
+        std::string access = (colonPos != std::string::npos) ? entry.substr(colonPos + 1) : "";
+
+        FsAccess fsAccess;
+        if (access == "ro") {
+            fsAccess = FsAccess::ReadOnly;
+        } else if (access == "create") {
+            fsAccess = FsAccess::Create;
+        } else {
+            fsAccess = FsAccess::ReadWrite;
+        }
+
+        permissions.push_back({ path, fsAccess });
+    }
+
+    return permissions;
+}

--- a/src/flatpak/fs_permissions.h
+++ b/src/flatpak/fs_permissions.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 lebachkhoa
+ * Flatguard is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+#include <string>
+#include <vector>
+
+enum class FsAccess
+{
+    ReadWrite,      // Read-write access (no suffix)
+    ReadOnly,       // Read-only access (:ro)
+    Create          // Create read-write access (:create)
+};
+
+struct FsPermission
+{
+    std::string path; 
+    FsAccess fsaccess;
+};
+
+namespace FlatpakParser
+{
+    std::vector<FsPermission> parseFilesystemPermissions(const std::vector<std::string>& fsEntries);
+};

--- a/src/flatpak/override.cpp
+++ b/src/flatpak/override.cpp
@@ -44,6 +44,7 @@ static void applyOverrideFile(AppPermissions& permissions, const std::filesystem
     applyList(permissions.sockets, overridePerms.sockets);
     applyList(permissions.devices, overridePerms.devices);
     applyList(permissions.filesystems, overridePerms.filesystems);
+    applyList(permissions.persistent, overridePerms.persistent);
 }
 
 void FlatpakParser::applyOverrides(AppPermissions& permissions, const std::filesystem::path& appPath)

--- a/src/flatpak/parser.cpp
+++ b/src/flatpak/parser.cpp
@@ -51,26 +51,22 @@ std::vector<AppPermissions> FlatpakParser::scanSystem()
     std::filesystem::path systemPath = "/var/lib/flatpak/app";
     std::vector<AppPermissions> allApps;
 
-    for (const auto& basePath : std::initializer_list<std::filesystem::path>{ systemPath, userPath })
-    {
+    for (const auto& basePath : std::initializer_list<std::filesystem::path>{ systemPath, userPath }) {
         if (!std::filesystem::exists(basePath)) continue;
 
-        try
-        {
+        try {
             for (const auto& appDir : std::filesystem::directory_iterator(basePath))
             {
                 std::filesystem::path metadataPath = appDir.path() / "current/active/metadata";
 
-                if (std::filesystem::exists(metadataPath))
-                {
+                if (std::filesystem::exists(metadataPath)){
                     AppPermissions appPerms = parseMetadata(metadataPath);
                     applyOverrides(appPerms, appDir.path());
                     allApps.push_back(appPerms);
                 }
             }
         }
-        catch (const std::exception& e)
-        {
+        catch (const std::exception& e) {
             std::cerr << "Error parsing metadata: " << basePath << " - " << e.what() << '\n';
         }
     }

--- a/src/flatpak/parser.h
+++ b/src/flatpak/parser.h
@@ -13,24 +13,26 @@
 
 struct AppPermissions
 {
-    std::string appId;
-    std::vector<std::string> shared;
-    std::vector<std::string> sockets;
-    std::vector<std::string> devices;
-    std::vector<std::string> filesystems;
+   std::string appId;
+   std::vector<std::string> shared;
+   std::vector<std::string> sockets;
+   std::vector<std::string> devices;
+   std::vector<std::string> filesystems;
+   std::vector<std::string> persistent;
 };
 
 namespace FlatpakParser
 {
-    inline constexpr const char* SECTION_APPLICATION   = "Application";
-    inline constexpr const char* KEY_NAME              = "name";
+   inline constexpr const char* SECTION_APPLICATION   = "Application";
+   inline constexpr const char* KEY_NAME              = "name";
 
-    inline constexpr const char* SECTION_CONTEXT       = "Context";
-    inline constexpr const char* KEY_SHARED            = "shared";
-    inline constexpr const char* KEY_SOCKETS           = "sockets";
-    inline constexpr const char* KEY_DEVICES           = "devices";
-    inline constexpr const char* KEY_FILESYSTEMS       = "filesystems";
-
-    AppPermissions parseMetadata(const std::filesystem::path& path);
-    std::vector<AppPermissions> scanSystem();
+   inline constexpr const char* SECTION_CONTEXT       = "Context";
+   inline constexpr const char* KEY_SHARED            = "shared";
+   inline constexpr const char* KEY_SOCKETS           = "sockets";
+   inline constexpr const char* KEY_DEVICES           = "devices";
+   inline constexpr const char* KEY_FILESYSTEMS       = "filesystems";
+   inline constexpr const char* KEY_PERSISTENT        = "persistent";
+   
+   AppPermissions parseMetadata(const std::filesystem::path& path);
+   std::vector<AppPermissions> scanSystem();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,8 +72,9 @@ void printAuditIssuesJson(const std::vector<AppPermissions>& apps,
         // Collect issues for this app
         std::vector<const AuditIssue*> appIssues;
         for (const auto& issue : allIssues)
-            if (issue.appId == app.appId)
+            if (issue.appId == app.appId) {
                 appIssues.push_back(&issue);
+            }
 
         bool hasAllDev = std::find(app.devices.begin(), app.devices.end(), "all") != app.devices.end();
 
@@ -85,14 +86,18 @@ void printAuditIssuesJson(const std::vector<AppPermissions>& apps,
 
         std::cout << "      \"shared\": [";
         for (size_t si = 0; si < app.shared.size(); ++si) {
-            if (si) std::cout << ", ";
+            if (si) {
+                std::cout << ", ";
+            }
             std::cout << "\"" << jsonEscape(app.shared[si]) << "\"";
         }
         std::cout << "],\n";
 
         std::cout << "      \"sockets\": [";
         for (size_t si = 0; si < app.sockets.size(); ++si) {
-            if (si) std::cout << ", ";
+            if (si) {
+                std::cout << ", ";
+            }
             std::cout << "\"" << jsonEscape(app.sockets[si]) << "\"";
         }
         std::cout << "],\n";
@@ -102,7 +107,9 @@ void printAuditIssuesJson(const std::vector<AppPermissions>& apps,
         } else {
             std::cout << "      \"devices\": [";
             for (size_t di = 0; di < app.devices.size(); ++di) {
-                if (di) std::cout << ", ";
+                if (di) {
+                    std::cout << ", ";
+                }
                 std::cout << "\"" << jsonEscape(app.devices[di]) << "\"";
             }
             std::cout << "],\n";
@@ -110,8 +117,19 @@ void printAuditIssuesJson(const std::vector<AppPermissions>& apps,
 
         std::cout << "      \"files\": [";
         for (size_t fi = 0; fi < app.filesystems.size(); ++fi) {
-            if (fi) std::cout << ", ";
+            if (fi) {
+                std::cout << ", ";
+            }
             std::cout << "\"" << jsonEscape(app.filesystems[fi]) << "\"";
+        }
+        std::cout << "],\n";
+
+        std::cout << "      \"persistent\": [";
+        for (size_t pi = 0; pi < app.persistent.size(); ++pi) {
+            if (pi) {
+                std::cout << ", ";
+            }
+            std::cout << "\"" << jsonEscape(app.persistent[pi]) << "\"";
         }
         std::cout << "]\n";
         std::cout << "    },\n";
@@ -124,19 +142,27 @@ void printAuditIssuesJson(const std::vector<AppPermissions>& apps,
             firstIssue = false;
 
             std::string sev;
-            if      (issue->severity == Severity::CRITICAL) sev = "CRITICAL";
-            else if (issue->severity == Severity::WARNING)   sev = "WARNING";
-            else                                              sev = "INFO";
+            if (issue->severity == Severity::CRITICAL) {
+                sev = "CRITICAL";
+            } else if (issue->severity == Severity::WARNING) {
+                sev = "WARNING";
+            } else {
+                sev = "INFO";
+            }
             std::cout << "      {\n";
             std::cout << "        \"ruleId\": \""      << jsonEscape(issue->ruleId)      << "\",\n";
             std::cout << "        \"severity\": \""    << sev                             << "\",\n";
             std::cout << "        \"description\": \"" << jsonEscape(issue->description) << "\"\n";
             std::cout << "      }";
         }
-        if (!firstIssue) std::cout << "\n";
+        if (!firstIssue) {
+            std::cout << "\n";
+        }
         std::cout << "    ]\n";
         std::cout << "  }";
-        if (ai + 1 < apps.size()) std::cout << ",";
+        if (ai + 1 < apps.size()) {
+            std::cout << ",";
+        }
         std::cout << "\n";
     }
     std::cout << "]\n";
@@ -148,10 +174,11 @@ void printAuditIssues(const std::vector<AppPermissions>& apps,
     for (const auto& app : apps) {
         // Collect issues for this app
         std::vector<const AuditIssue*> appIssues;
-        for (const auto& issue : allIssues)
-            if (issue.appId == app.appId)
+        for (const auto& issue : allIssues) {
+            if (issue.appId == app.appId) {
                 appIssues.push_back(&issue);
-
+            }
+        }
         bool hasAllDev = std::find(app.devices.begin(), app.devices.end(), "all") != app.devices.end();
         std::string devStr   = hasAllDev ? "all" : joinOrNone(app.devices);
         std::string filesStr = joinOrNone(app.filesystems);
@@ -163,10 +190,11 @@ void printAuditIssues(const std::vector<AppPermissions>& apps,
 
         // ── Permissions Summary ────────────────────────────────────────────
         std::cout << "[+] Permissions Summary:\n";
-        std::cout << "    - Shared:   " << joinOrNone(app.shared)      << "\n";
-        std::cout << "    - Sockets:  " << joinOrNone(app.sockets)     << "\n";
-        std::cout << "    - Devices:  " << devStr                      << "\n";
-        std::cout << "    - Files:    " << filesStr                    << "\n";
+        std::cout << "    - Shared:      " << joinOrNone(app.shared)      << "\n";
+        std::cout << "    - Sockets:     " << joinOrNone(app.sockets)     << "\n";
+        std::cout << "    - Devices:     " << devStr                      << "\n";
+        std::cout << "    - Files:       " << filesStr                    << "\n";
+        std::cout << "    - Persistent:  " << joinOrNone(app.persistent)  << "\n";
 
         // ── Security Findings ─────────────────────────────────────────────
         std::cout << "\n[!] Security Findings:\n";
@@ -220,7 +248,9 @@ int main(int argc, char* argv[])
     const auto& unmatched = result.unmatched();
     if (!unmatched.empty()) {
         std::cerr << RED << "Error: unrecognized argument(s):";
-        for (const auto& u : unmatched) std::cerr << " '" << u << "'";
+        for (const auto& u : unmatched) {
+            std::cerr << " '" << u << "'";
+        }
         std::cerr << RESET << std::endl;
         std::cerr << "Did you mean: " << BOLD << "--audit " << unmatched.back() << RESET << " ?" << std::endl;
         std::cout << options.help() << std::endl;
@@ -233,7 +263,7 @@ int main(int argc, char* argv[])
     }
 
     if (result.count("version")) {
-        std::cout << "flatguard v0.1.1" << std::endl;
+        std::cout << "flatguard v0.2.0" << std::endl;
         return 0;
     }
 

--- a/src/utils/ini_utils.cpp
+++ b/src/utils/ini_utils.cpp
@@ -54,4 +54,5 @@ void FlatpakParser::parsePermissionsFromIni(CSimpleIniA& ini, AppPermissions& pe
     readList(SECTION_CONTEXT, KEY_SOCKETS, perm.sockets);
     readList(SECTION_CONTEXT, KEY_DEVICES, perm.devices);
     readList(SECTION_CONTEXT, KEY_FILESYSTEMS, perm.filesystems);
+    readList(SECTION_CONTEXT, KEY_PERSISTENT, perm.persistent);
 }

--- a/tests/test_auditor.cpp
+++ b/tests/test_auditor.cpp
@@ -32,7 +32,7 @@ TEST(AuditorTests, DetectsFullDeviceAccess) {
     EXPECT_TRUE(foundDev01);
 }
 
-// Test case: Detect home directory access (filesystems=home) -> triggers FS_01 INFO
+// Test case: Detect home directory access (filesystems=home) -> triggers FS_01 WARNING
 TEST(AuditorTests, DetectsHomeAccess) {
     AppPermissions app;
     app.appId = "com.example.homeaccess";
@@ -43,7 +43,7 @@ TEST(AuditorTests, DetectsHomeAccess) {
     for (const auto& issue : issues) {
         if (issue.ruleId == "FS_01") {
             foundFs01 = true;
-            EXPECT_EQ(issue.severity, Severity::INFO);
+            EXPECT_EQ(issue.severity, Severity::WARNING);
         }
     }
     EXPECT_TRUE(foundFs01);
@@ -100,6 +100,59 @@ TEST(AuditorTests, ComboNetworkPlusHost) {
         }
     }
     EXPECT_TRUE(foundCombo02);
+}
+
+// host (rw) -> FS_02 must be CRITICAL
+TEST(AuditorTests, HostAccessIsCritical) {
+    AppPermissions app;
+    app.appId = "com.example.host";
+    app.filesystems = {"host"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "FS_02") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::CRITICAL);
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// host:ro -> FS_02 must be WARNING, description must say "read-only"
+TEST(AuditorTests, HostReadOnlyDowngradesToWarning) {
+    AppPermissions app;
+    app.appId = "com.example.hostro";
+    app.filesystems = {"host:ro"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "FS_02") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::WARNING);
+            EXPECT_NE(issue.description.find("read-only"), std::string::npos);
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// COMBO_02 with host:ro -> WARNING (not CRITICAL)
+TEST(AuditorTests, ComboNetworkPlusHostReadOnly) {
+    AppPermissions app;
+    app.appId = "com.example.combo02ro";
+    app.shared      = {"network"};
+    app.filesystems = {"host:ro"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "COMBO_02") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::WARNING);
+        }
+    }
+    EXPECT_TRUE(found);
 }
 
 // COMBO_03: Network + X11 socket -> risk of keylogging and remote data transmission
@@ -164,6 +217,126 @@ TEST(AuditorTests, AuditAllMultipleApps) {
 
     auto issues = Auditor::auditAll({app1, app2});
     EXPECT_GE(issues.size(), 2u);
+}
+
+// home:ro -> FS_01 stays INFO (read-only home is less severe than read/write)
+TEST(AuditorTests, HomeReadOnlyStaysInfo) {
+    AppPermissions app;
+    app.appId = "com.example.homero";
+    app.filesystems = {"home:ro"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "FS_01") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::INFO);
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// home:create -> FS_01 must be WARNING (writable)
+TEST(AuditorTests, HomeCreateStaysWarning) {
+    AppPermissions app;
+    app.appId = "com.example.homecreate";
+    app.filesystems = {"home:create"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "FS_01") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::WARNING);
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// COMBO_01 with home:ro -> WARNING, not CRITICAL
+TEST(AuditorTests, ComboNetworkPlusHomeReadOnly) {
+    AppPermissions app;
+    app.appId = "com.example.combo01ro";
+    app.shared      = {"network"};
+    app.filesystems = {"home:ro"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "COMBO_01") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::WARNING);
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// PERSIST_01: persistent=. triggers CRITICAL
+TEST(AuditorTests, DetectsPersistentHome) {
+    AppPermissions app;
+    app.appId = "com.example.persist01";
+    app.persistent = {"."};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "PERSIST_01") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::CRITICAL);
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// PERSIST_02: persistent=.config triggers WARNING
+TEST(AuditorTests, DetectsPersistentConfig) {
+    AppPermissions app;
+    app.appId = "com.example.persist02";
+    app.persistent = {".config"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "PERSIST_02") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::WARNING);
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// PERSIST_03: persistent=.ssh triggers CRITICAL
+TEST(AuditorTests, DetectsPersistentSsh) {
+    AppPermissions app;
+    app.appId = "com.example.persist03";
+    app.persistent = {".ssh"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "PERSIST_03") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::CRITICAL);
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// PERSIST_04: persistent=.gnupg triggers CRITICAL
+TEST(AuditorTests, DetectsPersistentGnupg) {
+    AppPermissions app;
+    app.appId = "com.example.persist04";
+    app.persistent = {".gnupg"};
+
+    auto issues = Auditor::auditApp(app);
+    bool found = false;
+    for (const auto& issue : issues) {
+        if (issue.ruleId == "PERSIST_04") {
+            found = true;
+            EXPECT_EQ(issue.severity, Severity::CRITICAL);
+        }
+    }
+    EXPECT_TRUE(found);
 }
 
 int main(int argc, char **argv) {

--- a/tests/test_fs_permissions.cpp
+++ b/tests/test_fs_permissions.cpp
@@ -1,0 +1,126 @@
+#include "gtest/gtest.h"
+#include "flatpak/fs_permissions.h"
+#include <vector>
+#include <string>
+
+// ── Basic access modifiers ────────────────────────────────────────────────────
+
+TEST(FsPermissionsTests, NoSuffixIsReadWrite)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"home"});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path,     "home");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::ReadWrite);
+}
+
+TEST(FsPermissionsTests, RoSuffixIsReadOnly)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"home:ro"});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path,     "home");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::ReadOnly);
+}
+
+TEST(FsPermissionsTests, CreateSuffixIsCreate)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"home:create"});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path,     "home");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::Create);
+}
+
+// ── Path varieties ────────────────────────────────────────────────────────────
+
+TEST(FsPermissionsTests, HostPath)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"host"});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path,     "host");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::ReadWrite);
+}
+
+TEST(FsPermissionsTests, AbsolutePath)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"/usr/share/myapp:ro"});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path,     "/usr/share/myapp");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::ReadOnly);
+}
+
+TEST(FsPermissionsTests, XdgPrefixPath)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"xdg-documents:ro"});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path,     "xdg-documents");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::ReadOnly);
+}
+
+TEST(FsPermissionsTests, HomeTildePath)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"~/Downloads"});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path,     "~/Downloads");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::ReadWrite);
+}
+
+// ── Multiple entries ──────────────────────────────────────────────────────────
+
+TEST(FsPermissionsTests, MultipleEntries)
+{
+    std::vector<std::string> entries = {"home:ro", "host", "/tmp:create"};
+    auto result = FlatpakParser::parseFilesystemPermissions(entries);
+
+    ASSERT_EQ(result.size(), 3u);
+
+    EXPECT_EQ(result[0].path,     "home");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::ReadOnly);
+
+    EXPECT_EQ(result[1].path,     "host");
+    EXPECT_EQ(result[1].fsaccess, FsAccess::ReadWrite);
+
+    EXPECT_EQ(result[2].path,     "/tmp");
+    EXPECT_EQ(result[2].fsaccess, FsAccess::Create);
+}
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+TEST(FsPermissionsTests, EmptyInputReturnsEmpty)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({});
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(FsPermissionsTests, EmptyStringEntryIsSkipped)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({""});
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(FsPermissionsTests, MixedWithEmptyEntries)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"", "home:ro", ""});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path, "home");
+}
+
+// ── Deny prefix '!' ───────────────────────────────────────────────────────────
+
+TEST(FsPermissionsTests, DenyEntryIsSkipped)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"!home"});
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(FsPermissionsTests, DenyEntriesMixedWithNormal)
+{
+    auto result = FlatpakParser::parseFilesystemPermissions({"!home", "host:ro", "!host"});
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].path,     "host");
+    EXPECT_EQ(result[0].fsaccess, FsAccess::ReadOnly);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Fixed in v0.2.0. home:ro is now correctly detected 
as an exfiltration risk when combined with network access.